### PR TITLE
Issue #14 - .NetStandard - Interception works 1 level, but not 2

### DIFF
--- a/src/Interceptors/InstanceInterceptors/InterfaceInterception/InterfaceInterceptorClassGenerator.cs
+++ b/src/Interceptors/InstanceInterceptors/InterfaceInterception/InterfaceInterceptorClassGenerator.cs
@@ -172,11 +172,12 @@ namespace Unity.Interception.Interceptors.InstanceInterceptors.InterfaceIntercep
             il.Emit(OpCodes.Ret);
         }
 
+        private static ModuleBuilder moduleBuilder = null;
         private void CreateTypeBuilder()
         {
             TypeAttributes newAttributes = TypeAttributes.Public | TypeAttributes.Class;
 
-            ModuleBuilder moduleBuilder = GetModuleBuilder();
+            moduleBuilder = moduleBuilder ?? GetModuleBuilder();
             _typeBuilder = moduleBuilder.DefineType(CreateTypeName(), newAttributes);
 
             _mainInterfaceMapper = DefineGenericArguments();


### PR DESCRIPTION
**[Issue 14](https://github.com/unitycontainer/interception/issues/14)**
In NetCore, interception will not work if more then 1 interface is setup to be intercepted.

**Reason:**
According to documentation in Emit, _only one ModuleBuilder per AssemblyBuilder can be created_

**Fix:**
Modified **InterfaceInterceptorClassGenerator** to follow a singleton pattern when creating a ModuleBuilder.