### PR TITLE
Add a cache of base method definitions to the pipeline manager

### DIFF
--- a/src/PolicyInjection/Pipeline/PipelineManager.cs
+++ b/src/PolicyInjection/Pipeline/PipelineManager.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using Unity.Interception.Interceptors;
@@ -17,9 +16,6 @@ namespace Unity.Interception.PolicyInjection.Pipeline
             new Dictionary<HandlerPipelineKey, HandlerPipeline>();
 
         private static readonly HandlerPipeline EmptyPipeline = new HandlerPipeline();
-
-        private static readonly ConcurrentDictionary<HandlerPipelineKey, MethodInfo> BaseMethodDefinitions =
-            new ConcurrentDictionary<HandlerPipelineKey, MethodInfo>();
 
         /// <summary>
         /// Retrieve the pipeline associated with the requested <paramref name="method"/>.
@@ -74,15 +70,13 @@ namespace Unity.Interception.PolicyInjection.Pipeline
                 return _pipelines[key];
             }
 
-            var baseMethodDefinition = BaseMethodDefinitions.GetOrAdd(key, k => method.GetBaseDefinition());
-
-            if (baseMethodDefinition == method)
+            if (method.GetBaseDefinition() == method)
             {
                 _pipelines[key] = new HandlerPipeline(handlers);
                 return _pipelines[key];
             }
 
-            var basePipeline = CreatePipeline(baseMethodDefinition, handlers);
+            var basePipeline = CreatePipeline(method.GetBaseDefinition(), handlers);
             _pipelines[key] = basePipeline;
             return basePipeline;
         }

--- a/src/PolicyInjection/Pipeline/PipelineManager.cs
+++ b/src/PolicyInjection/Pipeline/PipelineManager.cs
@@ -68,7 +68,7 @@ namespace Unity.Interception.PolicyInjection.Pipeline
 
         private HandlerPipeline CreatePipeline(MethodInfo method, IEnumerable<ICallHandler> handlers)
         {
-            HandlerPipelineKey key = HandlerPipelineKey.ForMethod(method);
+            var key = HandlerPipelineKey.ForMethod(method);
             if (_pipelines.ContainsKey(key))
             {
                 return _pipelines[key];

--- a/src/PolicyInjection/Pipeline/PipelineManager.cs
+++ b/src/PolicyInjection/Pipeline/PipelineManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using Unity.Interception.Interceptors;
@@ -16,6 +17,9 @@ namespace Unity.Interception.PolicyInjection.Pipeline
             new Dictionary<HandlerPipelineKey, HandlerPipeline>();
 
         private static readonly HandlerPipeline EmptyPipeline = new HandlerPipeline();
+
+        private static readonly ConcurrentDictionary<HandlerPipelineKey, MethodInfo> BaseMethodDefinitions =
+            new ConcurrentDictionary<HandlerPipelineKey, MethodInfo>();
 
         /// <summary>
         /// Retrieve the pipeline associated with the requested <paramref name="method"/>.
@@ -70,13 +74,15 @@ namespace Unity.Interception.PolicyInjection.Pipeline
                 return _pipelines[key];
             }
 
-            if (method.GetBaseDefinition() == method)
+            var baseMethodDefinition = BaseMethodDefinitions.GetOrAdd(key, k => method.GetBaseDefinition());
+
+            if (baseMethodDefinition == method)
             {
                 _pipelines[key] = new HandlerPipeline(handlers);
                 return _pipelines[key];
             }
 
-            var basePipeline = CreatePipeline(method.GetBaseDefinition(), handlers);
+            var basePipeline = CreatePipeline(baseMethodDefinition, handlers);
             _pipelines[key] = basePipeline;
             return basePipeline;
         }


### PR DESCRIPTION
This is a fix for https://github.com/unitycontainer/interception/issues/28. The same fix was made here https://github.com/unitycontainer/interception/pull/29, but was mistakenly rewritten in the git history, so it is now restored.
This PR should be merged only after this one: https://github.com/unitycontainer/interception/pull/37