### PR TITLE
Don't sign emitted interceptor assembly for net6.0 and higher

### DIFF
--- a/src/Interceptors/InstanceInterceptors/InterfaceInterception/InterfaceInterceptorClassGenerator.cs
+++ b/src/Interceptors/InstanceInterceptors/InterfaceInterception/InterfaceInterceptorClassGenerator.cs
@@ -31,6 +31,7 @@ namespace Unity.Interception.Interceptors.InstanceInterceptors.InterfaceIntercep
 
         static InterfaceInterceptorClassGenerator()
         {
+#if !NET6_0_OR_GREATER
             byte[] pair;
 
             using (MemoryStream ms = new MemoryStream())
@@ -42,13 +43,17 @@ namespace Unity.Interception.Interceptors.InstanceInterceptors.InterfaceIntercep
 
                 pair = ms.ToArray();
             }
+#endif
 
             AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
-                new AssemblyName("Unity_ILEmit_InterfaceProxies") { KeyPair = new StrongNameKeyPair(pair) },
+                new AssemblyName("Unity_ILEmit_InterfaceProxies")
+#if !NET6_0_OR_GREATER
+                    { KeyPair = new StrongNameKeyPair(pair) }
+#endif
 #if DEBUG_SAVE_GENERATED_ASSEMBLY
-                AssemblyBuilderAccess.RunAndSave);
+                , AssemblyBuilderAccess.RunAndSave);
 #else
-                AssemblyBuilderAccess.Run);
+                , AssemblyBuilderAccess.Run);
 #endif
         }
 

--- a/src/Unity.Interception.csproj
+++ b/src/Unity.Interception.csproj
@@ -19,7 +19,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>package.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <TargetFrameworks>netstandard2.0;net47;net46;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47;net46;net45;netcoreapp2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
.NET Core does not support emitted assembly signing, and a breaking change was introduced in .NET 6.0 to throw an exception instead of silently kipping the action. See: [.NET 6 strong name signing behavior breaks existing code.](https://github.com/dotnet/runtime/issues/69311)